### PR TITLE
Added alternative BS-Seq atoms

### DIFF
--- a/bs_tour_3b.yaml
+++ b/bs_tour_3b.yaml
@@ -1,0 +1,89 @@
+id: dgea_tour_3b
+name: 'BS-Seq analysis'
+description: 'Alignment of sequence reads against a reference genome using BWA'
+title_default: 'BS-Seq analysis'
+steps:
+  - title: '<b>Outline</b>'
+    element: ''
+    content: 'In this tour we will align MethylC sequenced reads against a
+reference<br />
+genome. This represents a necessary task for the quantification of<br />
+methilated Cytosines in CpG and CHG genomic contexts which can be later<br />
+used to infer and evaluate e.g. enhancer promoter or gene body<br />
+methilation rates.<br />
+Here, we will leverage on <b>BWA</b>.<br /><br />
+Click <b>Next</b> to start the analysis.<br />'
+    backdrop: true
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: '#tool-search-query'
+    content: 'Look for the <b>BWA</b> tool.<br />
+BWA is an efficient aligner for mapping sequence reads against a reference
+genome.<br />
+Here we want to align the sequences from the imported samples against<br />
+the provided reference genome.<br /><br />
+Click <b>Next</b> to load it.<br />'
+    placement: right
+    textinsert: bwa
+    postclick:
+      - >-
+        a[href$="/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fbwa%2Fbwa%2F0.7.17.4"]
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="reference_source|reference_source_selector"]'
+    content: 'Select <b>Use a genome from history and build index</b>.
+<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="reference_source|ref_file"]'
+    content: 'Select the imported reference genome from your history.
+<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="input_type|input_type_selector"]'
+    content: 'Select <b>Paired fastq</b>.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="input_type|fastq_input1"]'
+    content: 'Click on the dataset collection icon, and select the 1st read
+mate R1.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="input_type|fastq_input2"]'
+    content: 'Click on the dataset collection icon, and select the 2nd read
+mate R2.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="input_type|fastq_input2"]'
+    content: 'For all remaining parametrisation options, we will use the
+provided<br />
+default settings. However, for further information, please refer to the<br />
+manual provided below the tool box.<br /><br />
+Click <b>Next</b> to execute.<br />'
+    placement: bottom
+    postclick:
+      - '#execute'
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: '#right'
+    content: 'BWA processing has begun, and the results are loading in your
+history.<br />
+Results are available as soon as their entries turn green.<br /><br />
+Click <b>Next</b> to overview your data.<br />'
+    placement: left
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: ''
+    content: 'The alignment of sequence reads against a reference genome has
+been completed.<br />'
+    backdrop: true

--- a/bs_tour_3b.yaml
+++ b/bs_tour_3b.yaml
@@ -1,4 +1,4 @@
-id: dgea_tour_3b
+id: bs_tour_3b
 name: 'BS-Seq analysis'
 description: 'Alignment of sequence reads against a reference genome using BWA'
 title_default: 'BS-Seq analysis'

--- a/bs_tour_3c.yaml
+++ b/bs_tour_3c.yaml
@@ -32,7 +32,6 @@ Click <b>Next</b> to load it.<br />'
   - title: '<b>Map sequences against a reference genome</b>'
     element: 'div[tour_id="reference_genome|source"]'
     content: 'Select <b>Use a genome from history</b>.<br /><br />
- and specify the uploaded reference genome.<br />
 Click <b>Next</b> to overview further parametrisation options.<br />'
     placement: bottom
 

--- a/bs_tour_3c.yaml
+++ b/bs_tour_3c.yaml
@@ -1,0 +1,89 @@
+id: dgea_tour_3c
+name: 'BS-Seq analysis'
+description: 'Alignment of sequence reads against a reference genome using HISAT2'
+title_default: 'BS-Seq analysis'
+steps:
+  - title: '<b>Outline</b>'
+    element: ''
+    content: 'In this tour we will align MethylC sequenced reads against a
+reference<br />
+genome. This represents a necessary task for the quantification of<br />
+methilated Cytosines in CpG and CHG genomic contexts which can be later<br />
+used to infer and evaluate e.g. enhancer promoter or gene body<br />
+methilation rates.<br />
+Here, we will leverage on <b>HISAT2</b>.<br /><br />
+Click <b>Next</b> to start the analysis.<br />'
+    backdrop: true
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: '#tool-search-query'
+    content: 'Look for the <b>HISAT2</b> tool.<br />
+HISAT2 is an efficient aligner for mapping sequence reads against a reference
+genome.<br />
+Here we want to align the sequences from the imported samples against<br />
+the provided reference genome.<br /><br />
+Click <b>Next</b> to load it.<br />'
+    placement: right
+    textinsert: hisat2
+    postclick:
+      - >-
+        a[href$="/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fiuc%2Fhisat2%2Fhisat2%2F2.1.0%2Bgalaxy5"]
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="reference_genome|source"]'
+    content: 'Select <b>Use a genome from history</b>.<br /><br />
+ and specify the uploaded reference genome.<br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="reference_genome|history_item"]'
+    content: 'Select the imported reference genome from your history.
+<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="library|type"]'
+    content: 'Select <b>Paired-end</b>.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="library|input_1"]'
+    content: 'Click on the dataset collection icon, and select the 1st read
+mate R1.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="library|input_2"]'
+    content: 'Click on the dataset collection icon, and select the 2nd read
+mate R2.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="library|input_2"]'
+    content: 'For all remaining parametrisation options, we will use the
+provided<br />
+default settings. However, for further information, please refer to the<br />
+manual provided below the tool box.<br /><br />
+Click <b>Next</b> to execute.<br />'
+    placement: bottom
+    postclick:
+      - '#execute'
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: '#right'
+    content: 'HISAT2 processing has begun, and the results are loading in your
+history.<br />
+Results are available as soon as their entries turn green.<br /><br />
+Click <b>Next</b> to overview your data.<br />'
+    placement: left
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: ''
+    content: 'The alignment of sequence reads against a reference genome has
+been completed.<br />'
+    backdrop: true

--- a/bs_tour_3c.yaml
+++ b/bs_tour_3c.yaml
@@ -1,4 +1,4 @@
-id: dgea_tour_3c
+id: bs_tour_3c
 name: 'BS-Seq analysis'
 description: 'Alignment of sequence reads against a reference genome using HISAT2'
 title_default: 'BS-Seq analysis'

--- a/bs_tour_3d.yaml
+++ b/bs_tour_3d.yaml
@@ -1,0 +1,95 @@
+id: bs_tour_3d
+name: 'BS-Seq analysis'
+description: 'Alignment of sequence reads against a reference genome using Segemehl'
+title_default: 'BS-Seq analysis'
+steps:
+  - title: '<b>Outline</b>'
+    element: ''
+    content: 'In this tour we will align MethylC sequenced reads against a
+reference<br />
+genome. This represents a necessary task for the quantification of<br />
+methilated Cytosines in CpG and CHG genomic contexts which can be later<br />
+used to infer and evaluate e.g. enhancer promoter or gene body<br />
+methilation rates.<br />
+Here, we will leverage on <b>Segemehl</b>.<br /><br />
+Click <b>Next</b> to start the analysis.<br />'
+    backdrop: true
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: '#tool-search-query'
+    content: 'Look for the <b>Segemehl</b> tool.<br />
+Segemehl is an efficient aligner for mapping sequence reads against a reference
+genome.<br />
+Here we want to align the sequences from the imported samples against<br />
+the provided reference genome.<br /><br />
+Click <b>Next</b> to load it.<br />'
+    placement: right
+    textinsert: segemehl
+    postclick:
+      - >-
+        a[href$="/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Frnateam%2Fsegemehl%2Fsegemehl%2F0.2.0.4"]
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="refGenomeSource|genomeSource"]'
+    content: 'Select <b>Use one from the history</b>.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="refGenomeSource|own_reference_genome"]'
+    content: 'Select the imported reference genome from your history.
+<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="library|type"]'
+    content: 'Select <b>Paired-end</b>.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="library|mate_list_0|first_strand_query"]'
+    content: 'Click on the dataset collection icon, and select the 1st read
+mate R1.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="library|mate_list_0|second_strand_query"]'
+    content: 'Click on the dataset collection icon, and select the 2nd read
+mate R2.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="splitreads|splits"]'
+    content: 'Select <b>Split reads</b> to detect spliced variants within the
+samples.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="splitreads|splits"]'
+    content: 'For all remaining parametrisation options, we will use the
+provided<br />
+default settings. However, for further information, please refer to the<br />
+manual provided below the tool box.<br /><br />
+Click <b>Next</b> to execute.<br />'
+    placement: bottom
+    postclick:
+      - '#execute'
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: '#right'
+    content: 'Segemehl processing has begun, and the results are loading in your
+history.<br />
+Results are available as soon as their entries turn green.<br /><br />
+Click <b>Next</b> to overview your data.<br />'
+    placement: left
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: ''
+    content: 'The alignment of sequence reads against a reference genome has
+been completed.<br />'
+    backdrop: true

--- a/bs_tour_3e.yaml
+++ b/bs_tour_3e.yaml
@@ -1,0 +1,101 @@
+id: bs_tour_3e
+name: 'BS-Seq analysis'
+description: 'Alignment of sequence reads against a reference genome using STAR'
+title_default: 'BS-Seq analysis'
+steps:
+  - title: '<b>Outline</b>'
+    element: ''
+    content: 'In this tour we will align MethylC sequenced reads against a
+reference<br />
+genome. This represents a necessary task for the quantification of<br />
+methilated Cytosines in CpG and CHG genomic contexts which can be later<br />
+used to infer and evaluate e.g. enhancer promoter or gene body<br />
+methilation rates.<br />
+Here, we will leverage on <b>STAR</b>.<br /><br />
+Click <b>Next</b> to start the analysis.<br />'
+    backdrop: true
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: '#tool-search-query'
+    content: 'Look for the <b>STAR</b> tool.<br />
+STAR is an ultrafast and sensitive RNA-Seq aligner that maps sequence reads
+against a reference genome.<br />
+Here we want to align the sequences from the imported samples against<br />
+the provided reference genome.<br /><br />
+Click <b>Next</b> to load it.<br />'
+    placement: right
+    textinsert: rna star
+    postclick:
+      - >-
+        a[href$="/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fiuc%2Frgrnastar%2Frna_star%2F2.7.2b"]
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="singlePaired|sPaired"]'
+    content: 'Select <b>Paired-end (as individual datasets)</b>.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="singlePaired|input1"]'
+    content: 'Click on the dataset collection icon, and select the 1st read
+mate R1.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="singlePaired|input2"]'
+    content: 'Click on the dataset collection icon, and select the 2nd read
+mate R2.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="refGenomeSource|geneSource"]'
+    content: 'Select <b>Use reference genome from history and create temporary
+index</b>.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="refGenomeSource|genomeFastaFiles"]'
+    content: 'Select the imported reference genome from your history.
+<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="refGenomeSource|GTFconditional|GTFselect"]'
+    content: 'Select <b>build index with gene model</b>.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="refGenomeSource|GTFconditional|sjdbGTFfile"]'
+    content: 'Select the imported gene model from your history.<br /><br />
+Click <b>Next</b> to overview further parametrisation options.<br />'
+    placement: bottom
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: 'div[tour_id="refGenomeSource|GTFconditional|sjdbGTFfile"]'
+    content: 'For all remaining parametrisation options, we will use the
+provided<br />
+default settings. However, for further information, please refer to the<br />
+manual provided below the tool box.<br /><br />
+Click <b>Next</b> to execute.<br />'
+    placement: left
+    postclick:
+      - '#execute'
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: '#right'
+    content: 'STAR processing has begun, and the results are loading in your
+history.<br />
+Results are available as soon as their entries turn green.<br /><br />
+Click <b>Next</b> to overview your data.<br />'
+    placement: left
+
+  - title: '<b>Map sequences against a reference genome</b>'
+    element: ''
+    content: 'The alignment of sequence reads against a reference genome has
+been completed.<br />'
+    backdrop: true


### PR DESCRIPTION
Added alternative BS-Seq atoms for the mapping of MethylC reads against a reference genome:
- bs_tour_3b
- bs_tour_3c
- bs_tour_3d
- bs_tour_3e